### PR TITLE
Fix error when build failed

### DIFF
--- a/lib/drunker/executor.rb
+++ b/lib/drunker/executor.rb
@@ -25,7 +25,7 @@ module Drunker
 
           finished.select(&:failed?).each do |builder|
             builder.errors.each do |error|
-              logger.warn("Build failed: #{failed.build_id}")
+              logger.warn("Build failed: #{builder.build_id}")
               logger.warn("\tphase_type: #{error[:phase_type]}")
               logger.warn("\tphase_status: #{error[:phase_status]}")
               logger.warn("\tstatus: #{error[:status]}")


### PR DESCRIPTION
Fix this error.

```
INFO: Waiting builders: 0/1, queues: 0
INFO: Waiting builders: 0/1, queues: 0
INFO: Waiting builders: 0/1, queues: 0
INFO: Waiting builders: 0/1, queues: 0
/Users/watanabekazuma/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/drunker-0.1.1/lib/drunker/executor.rb:28:in `block (4 levels) in run': undefined local variable or method `failed' for #<Dru
nker::Executor:0x007fd5cadaead8> (NameError)
Did you mean?  fail
        from /Users/watanabekazuma/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/drunker-0.1.1/lib/drunker/executor.rb:27:in `each'
        from /Users/watanabekazuma/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/drunker-0.1.1/lib/drunker/executor.rb:27:in `block (3 levels) in run'
        from /Users/watanabekazuma/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/drunker-0.1.1/lib/drunker/executor.rb:26:in `each'
        from /Users/watanabekazuma/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/drunker-0.1.1/lib/drunker/executor.rb:26:in `block (2 levels) in run'
        from /Users/watanabekazuma/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/drunker-0.1.1/lib/drunker/executor.rb:19:in `loop'
        from /Users/watanabekazuma/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/drunker-0.1.1/lib/drunker/executor.rb:19:in `block in run'
        from /Users/watanabekazuma/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/drunker-0.1.1/lib/drunker/executor.rb:94:in `setup_project'
        from /Users/watanabekazuma/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/drunker-0.1.1/lib/drunker/executor.rb:16:in `run'
        from /Users/watanabekazuma/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/drunker-0.1.1/lib/drunker/cli.rb:45:in `_run'
        from /Users/watanabekazuma/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/thor-0.19.4/lib/thor/command.rb:27:in `run'
        from /Users/watanabekazuma/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/thor-0.19.4/lib/thor/invocation.rb:126:in `invoke_command'
        from /Users/watanabekazuma/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/thor-0.19.4/lib/thor.rb:369:in `dispatch'
        from /Users/watanabekazuma/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/thor-0.19.4/lib/thor/base.rb:444:in `start'
        from /Users/watanabekazuma/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/drunker-0.1.1/exe/drunker:6:in `<top (required)>'
        from /Users/watanabekazuma/.rbenv/versions/2.3.1/bin/drunker:23:in `load'
        from /Users/watanabekazuma/.rbenv/versions/2.3.1/bin/drunker:23:in `<main>'
```