### PR TITLE
Bump up default buildspec version to 0.2

### DIFF
--- a/lib/drunker/executor/buildspec.yml.erb
+++ b/lib/drunker/executor/buildspec.yml.erb
@@ -1,5 +1,5 @@
 ---
-version: 0.1
+version: 0.2
 phases:
   build:
     commands:

--- a/spec/executor/builder_spec.rb
+++ b/spec/executor/builder_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Drunker::Executor::Builder do
     it "starts new build" do
       yaml =<<YAML
 ---
-version: 0.1
+version: 0.2
 phases:
   build:
     commands:
@@ -76,7 +76,7 @@ YAML
       it "starts new build with interpolated buildspec" do
         yaml =<<YAML
 ---
-version: 0.1
+version: 0.2
 phases:
   build:
     commands:


### PR DESCRIPTION
Currently, CodeBuild supports buildspec version v0.2 as the latest version. 
https://forums.aws.amazon.com/ann.jspa?annID=4617

Drunker also uses v0.2 as the default buildspec version 🎉 